### PR TITLE
fix: use the path part of uri to resolve assets

### DIFF
--- a/.changes/asset-resolver-use-path-part.md
+++ b/.changes/asset-resolver-use-path-part.md
@@ -1,0 +1,5 @@
+---
+"tauri-plugin-localhost": minor
+---
+
+Use the path part of uri to resolve assets.

--- a/.changes/asset-resolver-use-path-part.md
+++ b/.changes/asset-resolver-use-path-part.md
@@ -1,5 +1,5 @@
 ---
-"tauri-plugin-localhost": minor
+"tauri-plugin-localhost": patch
 ---
 
 Use the path part of uri to resolve assets.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-localhost"
-version = "0.1.0"
+version = "0.1.1"
 authors = [ "Tauri Programme within The Commons Conservancy" ]
 description = "A Tauri Plugin that allows usage of a localhost server instead of the custom protocol in production builds"
 license = "Apache-2.0 OR MIT"
@@ -13,3 +13,4 @@ exclude = [ "/examples" ]
 tauri = "1"
 serde_json = "1.0"
 tiny_http = "0.11"
+http = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-localhost"
-version = "0.1.1"
+version = "0.1.0"
 authors = [ "Tauri Programme within The Commons Conservancy" ]
 description = "A Tauri Plugin that allows usage of a localhost server instead of the custom protocol in production builds"
 license = "Apache-2.0 OR MIT"

--- a/examples/vanilla/src-tauri/Cargo.lock
+++ b/examples/vanilla/src-tauri/Cargo.lock
@@ -2848,8 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-localhost"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "http",
  "serde_json",
  "tauri",
  "tiny_http",

--- a/examples/vanilla/src-tauri/src/main.rs
+++ b/examples/vanilla/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
   windows_subsystem = "windows"
 )]
 
+use std::path::PathBuf;
 use tauri::{utils::config::AppUrl, window::WindowBuilder, WindowUrl};
 
 #[tauri::command]
@@ -24,9 +25,13 @@ fn main() {
     .invoke_handler(tauri::generate_handler![my_custom_command])
     .plugin(tauri_plugin_localhost::Builder::new(port).build())
     .setup(move |app| {
-      WindowBuilder::new(app, "main".to_string(), window_url)
-        .title("Localhost Example")
-        .build()?;
+      WindowBuilder::new(
+        app,
+        "main".to_string(),
+        WindowUrl::App(PathBuf::from("index.html?action=edit")),
+      )
+      .title("Localhost Example")
+      .build()?;
       Ok(())
     })
     .run(context)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use http::Uri;
 use tauri::{
   plugin::{Builder as PluginBuilder, TauriPlugin},
   Runtime,
@@ -62,8 +63,9 @@ impl Builder {
           let server =
             Server::http(&format!("localhost:{}", port)).expect("Unable to spawn server");
           for req in server.incoming_requests() {
+            let uri = req.url().parse::<Uri>().expect("Unable to parse url");
             #[allow(unused_mut)]
-            if let Some(mut asset) = asset_resolver.get(req.url().into()) {
+            if let Some(mut asset) = asset_resolver.get(uri.path().into()) {
               let request = Request {
                 url: req.url().into(),
               };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,11 @@ impl Response {
   }
 }
 
+type OnRequest = Option<Box<dyn Fn(&Request, &mut Response) + Send + Sync>>;
+
 pub struct Builder {
   port: u16,
-  on_request: Option<Box<dyn Fn(&Request, &mut Response) + Send + Sync>>,
+  on_request: OnRequest,
 }
 
 impl Builder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,14 @@ impl Builder {
           let server =
             Server::http(&format!("localhost:{}", port)).expect("Unable to spawn server");
           for req in server.incoming_requests() {
-            let uri = req.url().parse::<Uri>().expect("Unable to parse url");
+            let path = req
+              .url()
+              .parse::<Uri>()
+              .map(|uri| uri.path().into())
+              .unwrap_or_else(|_| req.url().into());
+
             #[allow(unused_mut)]
-            if let Some(mut asset) = asset_resolver.get(uri.path().into()) {
+            if let Some(mut asset) = asset_resolver.get(path) {
               let request = Request {
                 url: req.url().into(),
               };


### PR DESCRIPTION
Use the path part of uri to resolve the asset, otherwise asset_resolver cannot find the asset when the uri contains other parts, such as query, fragment, etc.

For instance,  `/index.html?action=edit`,  we should use the path part ` index.html`(but not `/index.html?action=edit` )
to resolve the asset.